### PR TITLE
Extend support for subscriptions

### DIFF
--- a/lib/listener_struct.ex
+++ b/lib/listener_struct.ex
@@ -1,3 +1,3 @@
 defmodule Macrocosm.Listener do
-  defstruct uuid: nil, callback: nil
+  defstruct uuid: nil, callback: nil, unsub_on_run: false
 end

--- a/lib/listener_struct.ex
+++ b/lib/listener_struct.ex
@@ -1,0 +1,3 @@
+defmodule Macrocosm.Listener do
+  defstruct uuid: nil, callback: nil
+end

--- a/lib/macrocosm_struct.ex
+++ b/lib/macrocosm_struct.ex
@@ -1,3 +1,3 @@
 defmodule Macrocosm.Struct do
-  defstruct reducer: nil, state: nil, next_listeners: [], current_listeners: []
+  defstruct reducer: nil, state: nil, next_listeners: [], current_listeners: [], listeners_marked_for_unsub: []
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,6 +23,7 @@ defmodule Macrocosm.Mixfile do
     [
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      { :uuid, "~> 1.1" }
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,1 @@
+%{"uuid": {:hex, :uuid, "1.1.7", "007afd58273bc0bc7f849c3bdc763e2f8124e83b957e515368c498b641f7ab69", [], [], "hexpm"}}

--- a/test/helpers/listeners.exs
+++ b/test/helpers/listeners.exs
@@ -2,7 +2,7 @@ defmodule Test.Listeners do
   use GenServer
 
   def create() do
-    GenServer.start_link(__MODULE__, %{a_calls: 0, b_calls: 0}, name: __MODULE__)
+    GenServer.start_link(__MODULE__, %{a_calls: 0, b_calls: 0, c_calls: 0}, name: __MODULE__)
   end
 
   def a_calls do
@@ -13,6 +13,10 @@ defmodule Test.Listeners do
     GenServer.call(__MODULE__, :b_calls)
   end
 
+  def c_calls do
+    GenServer.call(__MODULE__, :c_calls)
+  end
+
   def listener_a do
     GenServer.call(__MODULE__, :listener_a)
   end
@@ -21,25 +25,38 @@ defmodule Test.Listeners do
     GenServer.call(__MODULE__, :listener_b)
   end
 
+  def listener_c do
+    GenServer.call(__MODULE__, :listener_c)
+  end
+
   #-----------------------------------------------------------------------------
   # GenServer Callbacks
   #-----------------------------------------------------------------------------
 
-  def handle_call(:listener_a, _from, %{a_calls: a_calls, b_calls: _} = state) do
+  def handle_call(:listener_a, _from, %{a_calls: a_calls, b_calls: _, c_calls: _} = state) do
     next_state = %{ state | a_calls: a_calls + 1 }
     {:reply, :ok, next_state}
   end
 
-  def handle_call(:listener_b, _from, %{a_calls: _, b_calls: b_calls} = state) do
+  def handle_call(:listener_b, _from, %{a_calls: _, b_calls: b_calls, c_calls: _} = state) do
     next_state = %{ state | b_calls: b_calls + 1 }
     {:reply, :ok, next_state}
   end
 
-  def handle_call(:a_calls, _from, %{a_calls: a_calls, b_calls: _} = state) do
+  def handle_call(:listener_c, _from, %{a_calls: _, b_calls: _, c_calls: c_calls} = state) do
+    next_state = %{ state | c_calls: c_calls + 1 }
+    {:reply, :ok, next_state}
+  end
+
+  def handle_call(:a_calls, _from, %{a_calls: a_calls, b_calls: _, c_calls: _} = state) do
     {:reply, a_calls, state}
   end
 
-  def handle_call(:b_calls, _from, %{a_calls: _, b_calls: b_calls} = state) do
+  def handle_call(:b_calls, _from, %{a_calls: _, b_calls: b_calls, c_calls: _} = state) do
     {:reply, b_calls, state}
+  end
+
+  def handle_call(:c_calls, _from, %{a_calls: _, b_calls: _, c_calls: c_calls} = state) do
+    {:reply, c_calls, state}
   end
 end

--- a/test/macrocosm_test.exs
+++ b/test/macrocosm_test.exs
@@ -1,5 +1,5 @@
 defmodule MacrocosmTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Macrocosm
 
   test 'it throws if the reducer is not a function' do
@@ -106,4 +106,26 @@ defmodule MacrocosmTest do
     Macrocosm.animate(Test.ActionCreators.unknown_action)
     assert Test.Listeners.a_calls == 1
   end
+
+  test 'it supports removing a subscription within a subscription' do
+    Macrocosm.create(&Test.Reducers.todos/2, %{todos: []})
+
+    Test.Listeners.create
+    listener_a = &Test.Listeners.listener_a/0
+    listener_b = &Test.Listeners.listener_b/0
+    listener_c = &Test.Listeners.listener_c/0
+
+    Macrocosm.subscribe(listener_a)
+    Macrocosm.subscribe_once(listener_b)
+    Macrocosm.subscribe(listener_c)
+
+    Macrocosm.animate(Test.ActionCreators.unknown_action)
+    Macrocosm.animate(Test.ActionCreators.unknown_action)
+
+    assert Test.Listeners.a_calls == 2
+    assert Test.Listeners.b_calls == 1
+    assert Test.Listeners.c_calls == 2
+  end
+
+
 end


### PR DESCRIPTION
This PR includes support for:

- Multiple unique listeners with the same callback function
- Subscriptions that run only once, then unsubscribe themselves